### PR TITLE
fix #2 hardcoded Windows font location

### DIFF
--- a/map_display.py
+++ b/map_display.py
@@ -140,7 +140,7 @@ class MapDisplay():
         self.screen_layout = redhex.Layout(redhex.layout_pointy, size, origin)
 
         #Setup font
-        self.font = pygame.font.Font('C:/WINDOWS/Fonts/arial.TTF', 14)
+        self.font = pygame.font.SysFont("Arial", 14)
         self.font.set_bold(1)
 
         #

--- a/redtest.py
+++ b/redtest.py
@@ -49,8 +49,7 @@ map_height = 21
 map_width = 28
 hex_org = redhex.Hex(0, 0, 0)
 
-#gf = pygame.font.Font('C:\WINDOWS\Fonts\ARIALN.TTF', 14)
-gf = pygame.font.Font('C:/WINDOWS/Fonts/arial.TTF', 14)
+gf = pygame.font.SysFont("Arial", 14)
 gf.set_bold(1)
 
 


### PR DESCRIPTION
Change the font set for pygame to use SysFont.
SysFont will default to the system default if the
requested font is not preset.